### PR TITLE
Change the blockrsync container to point to rsync-transfer

### DIFF
--- a/state_transfer/transfer/blockrsync/blockrsync.go
+++ b/state_transfer/transfer/blockrsync/blockrsync.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	blockrsyncImage     = "quay.io/awels/blockrsync:latest"
+	blockrsyncImage     = "quay.io/konveyor/rsync-transfer:latest"
 	volumeName          = "volume"
 	BlockRsyncContainer = "blockrsync"
 	Proxy               = "proxy"


### PR DESCRIPTION
The original PR is pointing to my personal repo. Now that we have https://github.com/migtools/rsync-transfer/pull/27 we can point the container to the correct image.