### PR TITLE
Allow setting of image for block rync

### DIFF
--- a/state_transfer/transfer/blockrsync/options.go
+++ b/state_transfer/transfer/blockrsync/options.go
@@ -24,3 +24,17 @@ func (t *TransferOptions) GetBlockrsyncClientImage() string {
 	}
 	return t.blockrsyncClientImage
 }
+
+type RsyncServerImage string
+
+func (r RsyncServerImage) ApplyTo(opts *TransferOptions) error {
+	opts.blockrsyncServerImage = string(r)
+	return nil
+}
+
+type RsyncClientImage string
+
+func (r RsyncClientImage) ApplyTo(opts *TransferOptions) error {
+	opts.blockrsyncClientImage = string(r)
+	return nil
+}


### PR DESCRIPTION
There was no mechanism to allow overriding of the default images for block rsync transfer pods. This PR allows the user of block rsync to override the used images