### PR TITLE
Fix the blockrsync container pulling the wrong image

### DIFF
--- a/state_transfer/transfer/blockrsync/client.go
+++ b/state_transfer/transfer/blockrsync/client.go
@@ -57,7 +57,7 @@ func createBlockrsyncClient(c client.Client, r *BlockrsyncTransfer, pvc transfer
 		{
 			Name:            BlockRsyncContainer,
 			ImagePullPolicy: v1.PullAlways,
-			Image:           blockrsyncImage,
+			Image:           r.transferOptions.GetBlockrsyncClientImage(),
 		},
 	}
 	addVolumeToContainer(pvc.Source().Claim(), pvc.Source().LabelSafeName(), pvc.Source().LabelSafeName(), &containers[1])


### PR DESCRIPTION
Missed that the blockrsync container was hardcoded to the default instead of using the added lookup code.