### PR TITLE
Allow nodeName to be set in blockrsync options

### DIFF
--- a/state_transfer/transfer/blockrsync/client.go
+++ b/state_transfer/transfer/blockrsync/client.go
@@ -97,6 +97,9 @@ func createBlockrsyncClient(c client.Client, r *BlockrsyncTransfer, pvc transfer
 			RestartPolicy: v1.RestartPolicyOnFailure,
 		},
 	}
+	if r.transferOptions.NodeName != "" {
+		pod.Spec.NodeName = r.transferOptions.NodeName
+	}
 
 	return c.Create(context.TODO(), &pod, &client.CreateOptions{})
 }

--- a/state_transfer/transfer/blockrsync/options.go
+++ b/state_transfer/transfer/blockrsync/options.go
@@ -9,6 +9,7 @@ type TransferOptions struct {
 	password              string
 	blockrsyncServerImage string
 	blockrsyncClientImage string
+	NodeName              string
 }
 
 func (t *TransferOptions) GetBlockrsyncServerImage() string {


### PR DESCRIPTION
If the source volume is RWO we need to ensure the
blockrsync client is started on the same node as the running pod. This change allows the nodeName to be set in the blockrsync options.