### PR TITLE
Return true if the PVC is filesystem but has correct annotations.

### DIFF
--- a/state_transfer/transfer/pvc_list.go
+++ b/state_transfer/transfer/pvc_list.go
@@ -127,6 +127,7 @@ func isBlockOrVMDisk(pvc *v1.PersistentVolumeClaim) bool {
 		if v, ok := pvc.GetAnnotations()[kubeVirtAnnKey]; !ok || v != kubevirtContentType {
 			return false
 		}
+		isBlock = true
 	}
 	return isBlock
 }


### PR DESCRIPTION
The return was missed and it was returning false even if it should return true.